### PR TITLE
Deploy newsletter debug

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
         "bmewburn.vscode-intelephense-client",
         "valeryanm.vscode-phpsab",
         "neilbrayfield.php-docblocker",
-        "spmeesseman.vscode-taskexplorer",
         "esbenp.prettier-vscode",
         "xdebug.php-debug",
         "jakebathman.mysql-syntax",

--- a/src/app/Controller/NewsletterSubscriptionController.php
+++ b/src/app/Controller/NewsletterSubscriptionController.php
@@ -80,6 +80,21 @@ final class NewsletterSubscriptionController extends AbstractController implemen
             $newsletter->subscribe($subscription);
     
             return $this->redirectToRoute('form_newsletter_subscription_received');
+        } catch (\InvalidArgumentException $e) { // Todo: Keep this in for debugging, but replace with a more specific exception in the future
+            $this->logger?->error(
+                'Failed to create newsletter subscription entity from form data.',
+                [
+                    'route' => $request->attributes->get('_route'),
+                    'data' => $data,
+                    'exception' => $e,
+                ]
+            );
+            $this->addFlash('error', 'Die eingegebene E-Mail-Adresse ist ungültig.');
+            return RequestHelper::redirectToOrigin(
+                $request,
+                default: $this->generateUrl('home'),
+                anchor: 'newsletter-subscription-widget'
+            );
         } catch (SubscriptionException $e) {
             if ($e->getCode() === SubscriptionException::ALREADY_SUBSCRIBED) {
                 return $this->redirectToRoute('form_newsletter_already_subscribed');

--- a/src/app/Controller/NewsletterSubscriptionController.php
+++ b/src/app/Controller/NewsletterSubscriptionController.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Jazzfreunde\App\Controller;
 
 use DateTime;
+use InvalidArgumentException;
 use Jazzfreunde\App\Entity\NewsletterSubscription;
 use Jazzfreunde\App\Exception\Contract\ConfirmationContractNotFoundException;
 use Jazzfreunde\App\Exception\Contract\ConfirmationPeriodExpiredException;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Form\FormInterface;
 
 use function is_array;
 
@@ -48,31 +50,25 @@ final class NewsletterSubscriptionController extends AbstractController implemen
         }
 
         if (!$form->isValid()) {
-            $this->logger?->error(
-                'Submitted invalid form data for jazzletter subscription.',
-                [
-                    'route' => $request->attributes->get('_route'),
-                    'form' => $form->getErrors(true, false),
-                    'data' => $form->getData(),
-                    'request' => $request->getContent(),
-                ]
-            );
-                
-            return new Response(status: Response::HTTP_BAD_REQUEST);
+            return $this->createBadRequestResponse($request, $form);
+        }
+
+        /**
+         * @var array<string, mixed>|null $data
+         */
+        $data = $form->getData();
+        if (!is_array($data)) {
+            throw new \LogicException('Unable to load form data');
+        }
+
+        try {
+            $subscription = new NewsletterSubscription(...$data);
+            $subscription->creationTime = new DateTime();
+        } catch (InvalidArgumentException) {
+            return $this->createBadRequestResponse($request, $form);
         }
         
         try {
-            /**
-             * @var array<string, mixed>|null $data
-             */
-            $data = $form->getData();
-            if (!is_array($data)) {
-                throw new \LogicException('Unable to load form data');
-            }
-    
-            $subscription = new NewsletterSubscription(...$data);
-            $subscription->creationTime = new DateTime();
-    
             $newsletter->subscribe($subscription);
     
             return $this->redirectToRoute('form_newsletter_subscription_received');
@@ -142,5 +138,27 @@ final class NewsletterSubscriptionController extends AbstractController implemen
     public function alreadySubscribed(): Response
     {
         return $this->render('@pages/newsletter/already-subscribed-notification.html.twig');
+    }
+
+    /**
+     * Creates a response for a bad request due to invalid form data.
+     *
+     * @param  Request       $request
+     * @param  FormInterface $form
+     * @return Response
+     */
+    private function createBadRequestResponse(Request $request, FormInterface $form): Response
+    {
+        $this->logger?->error(
+            'Submitted invalid form data for jazzletter subscription.',
+            [
+                'route' => $request->attributes->get('_route'),
+                'form' => $form->getErrors(true, false),
+                'data' => $form->getData(),
+                'request' => $request->getContent(),
+            ]
+        );
+                
+        return new Response(status: Response::HTTP_BAD_REQUEST, content: 'Invalid form data submitted.');
     }
 }

--- a/src/app/Controller/NewsletterSubscriptionController.php
+++ b/src/app/Controller/NewsletterSubscriptionController.php
@@ -5,20 +5,19 @@ declare(strict_types = 1);
 namespace Jazzfreunde\App\Controller;
 
 use DateTime;
-use InvalidArgumentException;
 use Jazzfreunde\App\Entity\NewsletterSubscription;
 use Jazzfreunde\App\Exception\Contract\ConfirmationContractNotFoundException;
 use Jazzfreunde\App\Exception\Contract\ConfirmationPeriodExpiredException;
 use Jazzfreunde\App\Exception\Newsletter\SubscriptionException;
 use Jazzfreunde\App\Form\NewsletterSubscriptionType;
 use Jazzfreunde\App\Service\Newsletter\NewsletterService;
+use Jazzfreunde\App\Service\Security\Request\RequestHelper;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use Symfony\Component\Form\FormInterface;
 
 use function is_array;
 
@@ -50,7 +49,21 @@ final class NewsletterSubscriptionController extends AbstractController implemen
         }
 
         if (!$form->isValid()) {
-            return $this->createBadRequestResponse($request, $form);
+            $this->logger?->warning(
+                'Submitted invalid form data for jazzletter subscription.',
+                [
+                    'route' => $request->attributes->get('_route'),
+                    'form' => $form->getErrors(true, false),
+                    'data' => $form->getData(),
+                    'request' => $request->getContent(),
+                ]
+            );
+            $this->addFlash('error', 'Die eingegebene E-Mail-Adresse ist ungültig.');
+            return RequestHelper::redirectToOrigin(
+                $request,
+                default: $this->generateUrl('home'),
+                anchor: 'newsletter-subscription-widget'
+            );
         }
 
         /**
@@ -60,15 +73,10 @@ final class NewsletterSubscriptionController extends AbstractController implemen
         if (!is_array($data)) {
             throw new \LogicException('Unable to load form data');
         }
-
+        
         try {
             $subscription = new NewsletterSubscription(...$data);
             $subscription->creationTime = new DateTime();
-        } catch (InvalidArgumentException) {
-            return $this->createBadRequestResponse($request, $form);
-        }
-        
-        try {
             $newsletter->subscribe($subscription);
     
             return $this->redirectToRoute('form_newsletter_subscription_received');
@@ -138,27 +146,5 @@ final class NewsletterSubscriptionController extends AbstractController implemen
     public function alreadySubscribed(): Response
     {
         return $this->render('@pages/newsletter/already-subscribed-notification.html.twig');
-    }
-
-    /**
-     * Creates a response for a bad request due to invalid form data.
-     *
-     * @param  Request       $request
-     * @param  FormInterface $form
-     * @return Response
-     */
-    private function createBadRequestResponse(Request $request, FormInterface $form): Response
-    {
-        $this->logger?->error(
-            'Submitted invalid form data for jazzletter subscription.',
-            [
-                'route' => $request->attributes->get('_route'),
-                'form' => $form->getErrors(true, false),
-                'data' => $form->getData(),
-                'request' => $request->getContent(),
-            ]
-        );
-                
-        return new Response(status: Response::HTTP_BAD_REQUEST, content: 'Invalid form data submitted.');
     }
 }

--- a/src/app/Controller/Security/VerificationCodeSecurityController.php
+++ b/src/app/Controller/Security/VerificationCodeSecurityController.php
@@ -17,7 +17,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Routing\Annotation\Route;
@@ -99,7 +98,9 @@ final class VerificationCodeSecurityController extends AbstractController implem
         $email ??= SessionHelper::getUserEmail($request->getSession());
 
         if (is_null($email)) {
-            throw new LogicException('Email address is required for verification.');
+            $this->logger?->info('User email could not be determined from the request or session.');
+            $this->addFlash('error', 'Diese Sitzung ist veraltet. Starten Sie den Anmeldevorgang bitte neu.');
+            return $this->redirect($this->generateUrl('security_code_login'));
         }
         $verificationCode = $verificationCodeHandler->createVerificationCode($email->value());
 

--- a/src/app/Form/NewsletterSubscriptionType.php
+++ b/src/app/Form/NewsletterSubscriptionType.php
@@ -8,6 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Formular für Newsletter Abonnement
@@ -23,7 +24,11 @@ final class NewsletterSubscriptionType extends AbstractType
     {
         $builder
             ->setAction((string) ($options['action'] ?? ''))
-            ->add('email', EmailType::class, ['label' => 'Geben Sie Ihre Email-Adresse an'])
+            ->add('email', EmailType::class, [
+                'label' => 'Geben Sie Ihre Email-Adresse an',
+                 'required' => true,
+                 'constraints' => [new Assert\Email(message: 'The email {{ value }} is not a valid email.',)],
+            ])
             ->add('subscribe', SubmitType::class, ['label' => 'Benachrichtige mich'])
             ->getForm();
     }

--- a/src/app/Service/Security/Request/RequestHelper.php
+++ b/src/app/Service/Security/Request/RequestHelper.php
@@ -16,11 +16,17 @@ abstract class RequestHelper
      * Redirects the user back to the origin page.
      *
      * @param Request $request
+     * @param string $default
+     * @param string $anchor
      * @return RedirectResponse
      */
-    public static function redirectToOrigin(Request $request, string $default): RedirectResponse
+    public static function redirectToOrigin(Request $request, string $default, string $anchor = ''): RedirectResponse
     {
         $url = self::getRedirectUri($request, $default);
+
+        if ($anchor !== '') {
+            $url .= '#'.$anchor;
+        }
 
         return new RedirectResponse($url);
     }

--- a/src/config/routes/endroid_qr_code.yaml
+++ b/src/config/routes/endroid_qr_code.yaml
@@ -1,0 +1,3 @@
+endroid_qr_code:
+    resource: "@EndroidQrCodeBundle/Resources/config/routes.yaml"
+    prefix: /qr-code

--- a/src/templates/components/newsletter/subscription-widget.html.twig
+++ b/src/templates/components/newsletter/subscription-widget.html.twig
@@ -7,6 +7,7 @@
 		<div id="newsletter-subscription-widget" class="w-full overflow-hidden">
 			<h2 class="text-xl md:text-2xl font-bold mb-2 text-blue">Sie möchten gerne auf dem Laufenden bleiben?</h2>
 			<p class="text-xl md:text-2xl mb-5 md:mb-8 font-bold text-orange">Abonnieren Sie unseren Newsletter.</p>
+			{% include 'components/util/error-flash.html.twig' %}
 			{{ form_start(subscription_form) }}
 			<div class="w-full flex flex-col md:flex-row gap-5 lg:gap-10">
 				<div class="relative w-full md:flex-shrink md:flex-grow">

--- a/src/tests/Service/Security/Request/RequestHelperTest.php
+++ b/src/tests/Service/Security/Request/RequestHelperTest.php
@@ -46,6 +46,21 @@ final class RequestHelperTest extends TestCase
     }
 
     /**
+     * Test that redirectToOrigin appends the anchor if provided.
+     */
+    #[Test]
+    public function redirectToOriginAppendsAnchor()
+    {
+        $request = new Request();
+        $default = 'https://example.com/default';
+        $anchor = 'section1';
+
+        $response = RequestHelper::redirectToOrigin($request, $default, $anchor);
+
+        $this->assertEquals($default.'#'.$anchor, $response->getTargetUrl());
+    }
+
+    /**
      * Test that getUserEmailFromPost returns an Email instance for a valid email.
      */
     #[Test]


### PR DESCRIPTION
This pull request improves the newsletter subscription user experience by enhancing form validation, error handling, and user feedback. It also introduces minor improvements to the request helper utility, adds error flash messages to the newsletter widget, and makes a small update to routing for QR code functionality.

**Newsletter Subscription Improvements:**

* Added email validation constraints to the `NewsletterSubscriptionType` form and made the email field required, ensuring only valid email addresses can be submitted.
* Improved error handling and user feedback in `NewsletterSubscriptionController`: invalid form submissions now trigger a warning log, show an error flash message, and redirect the user back to the subscription widget with an anchor. Additionally, invalid argument exceptions during subscription creation are now caught, logged, and handled gracefully with user feedback. [[1]](diffhunk://#diff-95aea6fb12c343c57f2995a81e6a349498e94cadae03597ed994129ce0667acdL51-R52) [[2]](diffhunk://#diff-95aea6fb12c343c57f2995a81e6a349498e94cadae03597ed994129ce0667acdL60-L64) [[3]](diffhunk://#diff-95aea6fb12c343c57f2995a81e6a349498e94cadae03597ed994129ce0667acdR77-R97)
* Included error flash messages in the newsletter subscription widget template to display feedback to users.

**Utility and Test Enhancements:**

* Extended `RequestHelper::redirectToOrigin` to support appending an anchor to the redirect URL, and added a corresponding test to ensure this functionality works as expected. [[1]](diffhunk://#diff-fd3d82352e490e4b917d7966d37ea146f8fc18040c296e12728dd00e617de168R19-R30) [[2]](diffhunk://#diff-14dee63b895f687093e5cb470cc063188d0dbadf1776027f2b7c5c88e2969873R48-R62)

**Other Improvements:**

* Improved error handling in the verification code security controller by providing user-friendly feedback and redirecting instead of throwing a logic exception when the email is missing.
* Added routing configuration for QR code functionality.
* Minor cleanup: removed an unused extension from `.devcontainer/devcontainer.json` and an unused import from `VerificationCodeSecurityController.php`. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L15) [[2]](diffhunk://#diff-637f7ad3fbdd69bc89c5dca5d712f0e793992f8a4ca9b104120d5eb4047e77f9L20)